### PR TITLE
Fixes issue with length flashing 0 Bytes

### DIFF
--- a/islands/Controls.tsx
+++ b/islands/Controls.tsx
@@ -75,7 +75,7 @@ export const controlStyles = `
 
 export default function Controls() {
   const { currentControls, setControl } = useContext(ControlContext);
-  console.log(currentControls);
+  
   return (
       <div class="controls-compression">
         <Toggle 

--- a/islands/EditorArea.tsx
+++ b/islands/EditorArea.tsx
@@ -36,7 +36,7 @@ export interface ByteLength {
 
 export default function EditorArea() {
   const [state, setState] = useState("");
-  
+  const [paneState, setPaneState] = useState(false);
   const [currentControls, setControl] = useState<ControlStates>({
     isGzipChecked: false,
     isBrotliChecked: false,
@@ -46,16 +46,15 @@ export default function EditorArea() {
   });
 
   const onInput = (target: HTMLTextAreaElement) => setState(target.value);
-  const onClick = () => setControl({ ...currentControls, paneState: !currentControls.paneState });
+  const onClick = () => setPaneState(!paneState);
 
   return (
     <>
       <ControlContext.Provider value={{ currentControls, setControl }}>
         <TextArea
           onInput={(e) => onInput(e.target as unknown as HTMLTextAreaElement)}
-          onClick={onClick}
         >
-          <div className="controls" data-pane={currentControls.paneState}>
+          <div className="controls" data-pane={paneState}>
             <Button onClick={onClick} />
             <Controls />
           </div>


### PR DESCRIPTION
Now when the value of the textarea doesn't change, the calculateByteSize won't run

This included times like opening and closing the drawer, and flipping any of the options toggle